### PR TITLE
Fixed error while trying to update tag - wrong route name

### DIFF
--- a/app/Http/Requests/UpdateTagRequest.php
+++ b/app/Http/Requests/UpdateTagRequest.php
@@ -23,7 +23,7 @@ class UpdateTagRequest extends FormRequest
                 'required',
             ],
             'slug' => [
-                'required', 'unique:tags,slug,'.$this->route('article')->id
+                'required', 'unique:tags,slug,'.$this->route('tag')->id
             ],
         ];
     }


### PR DESCRIPTION
The same issue as described in #1 , this time for update tag in administration.